### PR TITLE
Implement embedded-hal 1.0 traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ edition = "2021"
 targets = [ "thumbv7m-none-eabi", "thumbv7em-none-eabihf" ]
 
 [dependencies]
-embedded-hal = "^ 0.2"
-display-interface = "^ 0.4"
+embedded-hal = "^ 1.0"
+display-interface = "^ 0.5"
 embedded-graphics-core = { version = "^ 0.4", optional = true }
 
 [dev-dependencies]
@@ -25,8 +25,8 @@ cortex-m = "^ 0.7"
 cortex-m-rt = "^ 0.7"
 embedded-graphics = "^ 0.8"
 panic-semihosting = "^ 0.6"
-display-interface-i2c = "^ 0.4"
-display-interface-spi = "^ 0.4"
+display-interface-i2c = "^ 0.5"
+display-interface-spi = "^ 0.5"
 
 [dev-dependencies.stm32f1xx-hal]
 version = "^ 0.10"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -44,7 +44,7 @@
 //! ```
 
 use core::marker::PhantomData;
-use hal::{self, digital::v2::OutputPin};
+use hal::{self, digital::{ErrorKind, ErrorType, OutputPin}};
 
 use crate::{
     displayrotation::DisplayRotation,
@@ -117,12 +117,30 @@ impl<PinE> NoOutputPin<PinE> {
     }
 }
 
-impl<PinE> OutputPin for NoOutputPin<PinE> {
-    type Error = PinE;
-    fn set_low(&mut self) -> Result<(), PinE> {
+#[derive(Debug, Clone, Copy)]
+/// Implement error type for NoOutputPin, required by OutputPin trait in embedded-hal 1.0
+pub enum Error {
+    /// This isn't a pin, so you can't change it's outputs
+    NotAPin
+}
+
+/// Required trait by embedded-hal 1.0
+impl hal::digital::Error for Error {
+    /// Needs to return 
+    fn kind(&self) -> ErrorKind {
+        ErrorKind::Other
+    }
+}
+
+impl ErrorType for NoOutputPin {
+  type Error = Error;
+}
+
+impl OutputPin for NoOutputPin {
+    fn set_low(&mut self) -> Result<(), Error> {
         Ok(())
     }
-    fn set_high(&mut self) -> Result<(), PinE> {
+    fn set_high(&mut self) -> Result<(), Error> {
         Ok(())
     }
 }
@@ -130,7 +148,7 @@ impl<PinE> OutputPin for NoOutputPin<PinE> {
 #[cfg(test)]
 mod tests {
     use super::NoOutputPin;
-    use embedded_hal::digital::v2::OutputPin;
+    use embedded_hal::digital::OutputPin;
 
     enum SomeError {}
 

--- a/src/mode/graphics.rs
+++ b/src/mode/graphics.rs
@@ -16,7 +16,7 @@
 //! ```
 
 use display_interface::{DisplayError, WriteOnlyDataCommand};
-use hal::{blocking::delay::DelayMs, digital::v2::OutputPin};
+use hal::{delay::DelayNs, digital::OutputPin};
 
 use crate::{
     displayrotation::DisplayRotation,
@@ -72,7 +72,7 @@ where
     ) -> Result<(), PinE>
     where
         RST: OutputPin<Error = PinE>,
-        DELAY: DelayMs<u8>,
+        DELAY: DelayNs,
     {
         rst.set_high()?;
         delay.delay_ms(10);


### PR DESCRIPTION
The embedded-hal crate released a 1.0 version, and there are some [breaking changes](https://github.com/rust-embedded/embedded-hal/blob/master/docs/migrating-from-0.2-to-1.0.md), like new traits. The latest version of display-interface expects those traits now too. So, I hacked together an update to this library to implement them.

Probably not production ready, but thought it might be helpful.